### PR TITLE
Add blank line before EOF in cron

### DIFF
--- a/conf/cron
+++ b/conf/cron
@@ -1,3 +1,4 @@
 * * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/public/index.php scheduled-activities
 * * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/public/index.php scheduled-video-clips
 * * * * * __APP__ /usr/bin/php__PHPVERSION__ __FINALPATH__/public/index.php scheduled-websub-publish
+


### PR DESCRIPTION
Closes #67, hopefully.

> I found this in syslog don't know exactly what it wants me to do .. Jul 18 16:23:01 [localhost](http://localhost/) cron[439]: (*system*castopod) ERROR (Missing newline before EOF, this crontab file will be ignored)

From [discussion](https://matrix.to/#/!BXzpAQtlPrIBZsjMRj:libera.chat/$M0JC9exfpJyCOMsba0g6It2eh0b7dgA3pDdfbF_Jc0Q?via=libera.chat&via=matrix.org) in our support chatroom.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
