### PR TITLE
Sql update

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Hosting platform made for podcasters",
         "fr": "Plateforme d'hébergement conçue pour les podcasteurs"
     },
-    "version": "1.0.0-99~ynh1",
+    "version": "1.0.0-99~ynh2",
     "url": "https://castopod.org/",
     "upstream": {
         "license": "GPL-3.0-only",

--- a/scripts/from_beta_16.sql
+++ b/scripts/from_beta_16.sql
@@ -1,0 +1,11 @@
+SET AUTOCOMMIT = 0;
+START TRANSACTION;
+
+ALTER TABLE `cp_settings`
+ADD COLUMN context VARCHAR(255) NULL AFTER `type`;
+
+ALTER TABLE cp_podcasts ADD COLUMN published_at DATETIME DEFAULT NULL AFTER 
+updated_by;
+UPDATE cp_podcasts SET published_at = created_at;
+
+COMMIT;

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -123,7 +123,7 @@ chown -R $app:www-data "$final_path"
 if ynh_compare_current_package_version --comparison eq --version 1.0.0-96~ynh1
 then
 	ynh_script_progression --message="Upgrading MySQL configuration..." --weight=1
-    ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name < ./from_beta_16.sql.sql
+    ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name < ./from_beta_16.sql
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -117,6 +117,16 @@ chmod -R o-rwx "$final_path"
 chown -R $app:www-data "$final_path"
 
 #=================================================
+# MYSQL CONFIGURATION
+#=================================================
+
+if ynh_compare_current_package_version --comparison eq --version 1.0.0-96~ynh1
+then
+	ynh_script_progression --message="Upgrading MySQL configuration..." --weight=1
+    ynh_mysql_connect_as --user=$db_name --password=$db_pwd --database=$db_name < ./from_beta_16.sql.sql
+fi
+
+#=================================================
 # NGINX CONFIGURATION
 #=================================================
 ynh_script_progression --message="Upgrading NGINX web server configuration..." --weight=10


### PR DESCRIPTION
## Problem

Instances on beta16 need to update the database before the app can be upgraded

## Solution

- Added required sql script
- Checks if the current version is beta16 and then applies the patch

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
