### PR TITLE
Restore data directory with proper permissions

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -21,6 +21,16 @@ chmod -R o-rwx "$install_dir"
 chown -R $app:www-data "$install_dir"
 
 #=================================================
+# RESTORE THE DATA DIRECTORY
+#=================================================
+ynh_script_progression --message="Restoring the data directory..." --weight=1
+
+ynh_restore_file --origin_path="$data_dir" --not_mandatory
+
+chown -R $app:www-data "$data_dir"
+chmod -R 750 $data_dir
+
+#=================================================
 # RESTORE THE MYSQL DATABASE
 #=================================================
 ynh_script_progression --message="Restoring the MySQL database..." --weight=2


### PR DESCRIPTION
## Problem

- Castopod not restoring `$data_dir` and also #125 when installed after uninstall with no data purge

## Solution

- Restore the directory
- Apply ownership as the old user no longer exists

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
